### PR TITLE
Fixed whitespace at end of dev file

### DIFF
--- a/emerging.dev.conll
+++ b/emerging.dev.conll
@@ -16739,4 +16739,4 @@ on	O
 Discivery	B-corporation
 Channel	I-corporation
 !	O
-﻿
+


### PR DESCRIPTION
The final line in `emerging.dev.conll` the finale line had a string character `b'\xef\xbb\xbf'` rather then the empty line `b''` that the other files have. This PR fixes that.